### PR TITLE
Add IP address in debug log.

### DIFF
--- a/src/main/java/org/icatproject/authn_ldap/LDAP_Authenticator.java
+++ b/src/main/java/org/icatproject/authn_ldap/LDAP_Authenticator.java
@@ -167,7 +167,7 @@ public class LDAP_Authenticator {
 
 		}
 
-		logger.debug("Login request by: " + username);
+		logger.debug("Login request by: {} from {}", username, (ip != null ? ip : "?"));
 
 		if (username == null || username.isEmpty()) {
 			throw new AuthnException(HttpURLConnection.HTTP_FORBIDDEN, "username cannot be null or empty.");


### PR DESCRIPTION
In deployments with non-trivial network configuration (e.g. proxies), it is not always obvious, which IP address the authentication plugin will see the request coming from. But this may be important to configure the `ip` attribute in `run.properties`. In such situations it may be useful if the IP address is logged in the debug output.

See also icatproject/authn.simple#1.