### PR TITLE
Remove existing MySQL installation on GitHub Actions for ICAT Ansible

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -62,6 +62,13 @@ jobs:
       - name: Change hostname to localhost
         run: sudo hostname -b localhost
 
+      # Remove existing MySQL installation so it doesn't interfere with GitHub Actions
+      - name: Remove existing mysql
+        run: |
+          sudo apparmor_parser -R /etc/apparmor.d/usr.sbin.mysqld
+          sudo apt-get remove --purge "mysql*"
+          sudo rm -rf /var/lib/mysql* /etc/mysql
+
       # Create local instance of ICAT
       - name: Run ICAT Ansible Playbook
         run: |


### PR DESCRIPTION
## Description
This PR is the result of merging https://github.com/icatproject-contrib/icat-ansible/pull/78 on ICAT Ansible. That PR fixes some bugs relating to the installation of mariadb. For GitHub Actions, the existing installation of mysql must be removed so it doesn't interfere with the one installed by ICAT Ansible. This PR just adds that step in.

## Testing Instructions
Just check that CI passes.

- [ ] Check GitHub Actions build